### PR TITLE
Changed references to head with temp

### DIFF
--- a/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
+++ b/com/williamfiset/algorithms/datastructures/linkedlist/DoublyLinkedList.java
@@ -99,13 +99,12 @@ public class DoublyLinkedList<T> implements Iterable<T> {
 		Node<T> temp=head;
 		for(int i=0;i<index-1;i++)
 		{
-			head=head.next;
+			temp=temp.next;
 		}
 		Node<T> newNode = new Node(data,null,null);
-		newNode.next=head.next;
-		newNode.prev=head.prev;
-		head.next=newNode;
-		head=temp;
+		newNode.next=temp.next;
+		newNode.prev=temp.prev;
+		temp.next=newNode;
 		
 		size++;
 	}


### PR DESCRIPTION
As suggested, I have changed the way traversing was taking place by changing references to head with temp. Now, temp is being used for traversing instead of head.